### PR TITLE
Don't cache responses that depend on client IP

### DIFF
--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 // Various CoreDNS constants.
 const (
-	CoreVersion = "1.10.1"
+	CoreVersion = "1.10.1.lg.1"
 	coreName    = "CoreDNS"
 	serverType  = "dns"
 )


### PR DESCRIPTION
Don't cache responses that depend on client IP, i.e. responses where the ECS source scope is nonzero

Addresses https://github.com/privacy-hero/issues/issues/6190 by simply bypassing caching